### PR TITLE
Added support for coinbase. See pull req for more documentation.

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -5,6 +5,7 @@
         <item>Bitstamp</item>
         <item>Crypto X Change</item>
         <item>BTC-e</item>
+        <item>Coinbase</item>
     </string-array>
 
     <string-array name="serviceValues">
@@ -13,6 +14,7 @@
         <item>BITSTAMP</item>
         <item>CRYPTOXCHANGE</item>
         <item>BTCE</item>
+        <item>COINBASE</item>
     </string-array>
 
     <string-array name="colorModeList">

--- a/src/st/brothas/mtgoxwidget/MtGoxTickerUtil.java
+++ b/src/st/brothas/mtgoxwidget/MtGoxTickerUtil.java
@@ -20,6 +20,7 @@ package st.brothas.mtgoxwidget;
 import android.util.Log;
 import org.json.JSONException;
 import org.json.JSONObject;
+import java.util.Arrays;
 
 import static st.brothas.mtgoxwidget.MtGoxWidgetProvider.LOG_TAG;
 
@@ -28,37 +29,25 @@ import static st.brothas.mtgoxwidget.MtGoxWidgetProvider.LOG_TAG;
   */
 public class MtGoxTickerUtil {
 
-    // TODO: Change to one method with "String... objects"
-    public static String getJSONTickerKeyFromObjects(JSONObject json, String objectNameLevel1, String objectNameLevel2,
-                                                     String key) {
-        JSONObject tickerObject;
-		try {
-			tickerObject = json.getJSONObject(objectNameLevel1).getJSONObject(objectNameLevel2);
-			return tickerObject.getString(key);
-		} catch (JSONException e) {
-			Log.e(LOG_TAG, "Error when getting JSON object1: '" + objectNameLevel1 + "', object2: '" + objectNameLevel2 +
-                    "'," + " key: '" + key + "', from json: '" + json + "'", e);
-		}
-		return "N/A";
-    }
-
-    public static String getJSONTickerKeyFromObject(JSONObject json, String objectName, String key) {
-        try {
-            return json.getJSONObject(objectName).getString(key);
-        } catch (JSONException e) {
-            Log.e(LOG_TAG, "Error when getting JSON object: '" + objectName + "'," + " key: '" + key +
-                    "', from json: '" + json + "'", e);
+    public static String getJSONTickerKey(JSONObject json, String... objectNames) {
+        JSONObject tickerObject = json;
+        String key = objectNames[objectNames.length - 1];
+        
+        for (int i = 0; i < objectNames.length - 1; i++) {
+            try {
+                tickerObject = tickerObject.getJSONObject(objectNames[i]);
+            } catch (JSONException e) {
+                Log.e(LOG_TAG, "Error when getting JSON at path: '" + Arrays.toString(objectNames) + "', from json: '" + json + "'", e);
+                return "N/A";
+            }
         }
-        return "N/A";
-    }
 
-    public static String getJSONTickerKey(JSONObject json, String key) {
-		try {
-			return json.getString(key);
-		} catch (JSONException e) {
-			Log.e(LOG_TAG, "Error when getting JSON key: '" + key + "' from json: '" + json + "'", e);
-		}
-		return "N/A";
+        try {
+            return tickerObject.getString(key);
+        } catch (JSONException e) {
+            Log.e(LOG_TAG, "Error when getting JSON at path: '" + Arrays.toString(objectNames) + "', from json: '" + json + "'", e);
+            return "N/A";
+        }
     }
 
     public static Double tryToParseDouble(String last) {

--- a/src/st/brothas/mtgoxwidget/MtGoxWidgetProvider.java
+++ b/src/st/brothas/mtgoxwidget/MtGoxWidgetProvider.java
@@ -247,7 +247,7 @@ public class MtGoxWidgetProvider extends AppWidgetProvider {
         // If there's only one URL, just return the first (for backwards compatability)
         if (combined.length() == 1) {
             try {
-                return combined.getJSONObject("url1");
+                return combined.getJSONObject("url0");
             } catch (JSONException e) {
                 Log.e(LOG_TAG, "Error when uncombining JSON", e);
             }


### PR DESCRIPTION
I added support for coinbase. Coinbase doesn't have a unified ticker URL, so I modified the TickerUrl stuff to handle an array of ticker urls. I preserved the old interface, but you can also include an array of strings and they'll all be fetched. The JSON object returned will look like: {"url0": {data from first url}, "url1": {data from second url}}. If only one URL is used, the old object will be returned (e.g. {"amount": 123, "currency": "USD"}).
